### PR TITLE
feat(US-5.2): Implement Update Ingredient

### DIFF
--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -310,6 +310,7 @@
       "quantity": "Quantity",
       "unit": "Unit",
       "cost": "Cost",
+      "notes": "Notes",
       "percentOfTotal": "% of Total",
       "unitType": "Unit Type",
       "totalIngredientsCost": "Total Ingredients Cost",

--- a/src/renderer/src/i18n/locales/nl.json
+++ b/src/renderer/src/i18n/locales/nl.json
@@ -310,6 +310,7 @@
       "quantity": "Hoeveelheid",
       "unit": "Eenheid",
       "cost": "Kosten",
+      "notes": "Notities",
       "percentOfTotal": "% van Totaal",
       "unitType": "Eenheidstype",
       "totalIngredientsCost": "Totale Ingrediëntenkosten",

--- a/src/renderer/src/pages/EditRecipePage.css
+++ b/src/renderer/src/pages/EditRecipePage.css
@@ -476,3 +476,26 @@
   font-size: 0.875rem;
   margin: 0;
 }
+
+/* Inline edit with error */
+.edit-recipe-page .inline-edit-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.25rem;
+}
+
+.edit-recipe-page .inline-input-error {
+  border-color: var(--color-error);
+}
+
+.edit-recipe-page .inline-error {
+  font-size: 0.7rem;
+  color: var(--color-error);
+  white-space: nowrap;
+}
+
+.edit-recipe-page .inline-input-notes {
+  width: 120px;
+  text-align: left;
+}


### PR DESCRIPTION
## Summary

- Add inline editing for ingredient notes in the recipe edit page
- Add inline validation with error messages for quantity field
- Show error when quantity is empty, zero, or negative
- Clear error when user starts typing valid input
- Notes column displays "-" when no notes are set
- Updated footer colspan to account for new notes column

## Acceptance Criteria

- [x] Quantity editable inline in ingredient row
- [x] Unit changeable via dropdown (kg/g)
- [x] Notes editable
- [x] Line cost updates as quantity changes
- [x] Total material cost updates
- [x] Quantity must be > 0 (validation)
- [x] Inline error message if invalid
- [x] Changes saved when recipe is saved

## Test Plan

- [ ] **Change Quantity**: Edit Beef 2kg = €50, change to 3kg, verify cost shows €75
- [ ] **Change Unit**: Change 1000g to 1kg, verify cost remains the same
- [ ] **Invalid Quantity**: Clear quantity field, verify error message appears; enter 0, verify error
- [ ] **Update Notes**: Add notes to an ingredient, save recipe, reload, verify notes preserved
- [ ] **Multiple Edits**: Change 3 ingredients, save, verify all changes persisted
- [ ] **Cancel Edit**: Start editing, click cancel, verify original values restored
- [ ] **Translations**: Switch to Dutch, verify error messages and notes label are translated

🤖 Generated with [Claude Code](https://claude.com/claude-code)